### PR TITLE
FACILITY-15955 updated unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self';";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy /wp-content/uploads/ -> s3 bucket
@@ -45,7 +50,7 @@ http {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             proxy_pass https://s3-us-west-2.amazonaws.com/img-sunrisehouse-com/wp-content/uploads/;
         }
-        
+
         # Media: images, icons, video, audio, HTC, 4 hours
         location ~* \.(?:jpg|jpeg|gif|png|ico|cur|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
@@ -88,8 +93,13 @@ http {
         server_name www.sunrisehouse.com;
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         return 301 https://sunrisehouse.com$request_uri;


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/FACILITY-15955

Description:
FACILITY-15955 updated unserved file types

Example Links:
https://staging.sunrisehouse.com/test.bak
https://staging.sunrisehouse.com/test.zip
https://staging.sunrisehouse.com/test.tar
https://staging.sunrisehouse.com/test.gz
https://staging.sunrisehouse.com/test.sql
https://staging.sunrisehouse.com/test.php
https://staging.sunrisehouse.com/test.env
https://staging.sunrisehouse.com/test.aspx
https://staging.sunrisehouse.com/test.env.aspx
https://staging.sunrisehouse.com/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.sunrisehouse.com/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/sunrisehouse-com-nginx/assets/86256771/6046b219-74b9-40f0-bedc-14de3c095407)
